### PR TITLE
Allow to force extact background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ colo seoul256-light
 
 ```
 
+You can also force the extact background you like:
+
+```vim
+let g:seoul256_forced_background = 233
+colo seoul256
+```
+
 Author
 ------
 

--- a/colors/seoul256-light.vim
+++ b/colors/seoul256-light.vim
@@ -99,7 +99,12 @@ function! s:hi(item, fg, bg)
   endif
 endfunction
 
-let s:seoul256_background = min([max([get(g:, 'seoul256_background', 253), 252]), 256])
+if get(g:, "seoul256_forced_background", 0)
+  let s:seoul256_background = g:seoul256_forced_background
+else
+  let s:seoul256_background = min([max([get(g:, 'seoul256_background', 253), 252]), 256])
+endif
+
 let s:seoul256_background1 = min([s:seoul256_background + 1, 255])
 let s:seoul256_background2 = min([s:seoul256_background + 2, 255])
 
@@ -286,7 +291,7 @@ call s:hi('GitGutterChange', 65, '')
 call s:hi('GitGutterDelete', 161, '')
 call s:hi('GitGutterChangeDelete', 168, '')
 
-" http://vim.wikia.com/wiki/Highlight_unwanted_spaces     
+" http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 " ---------------------------------------------------^^^^^
 call s:hi('ExtraWhitespace', '', s:seoul256_background - 2)
 

--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -97,7 +97,11 @@ function! s:hi(item, fg, bg)
   endif
 endfunction
 
-let s:seoul256_background = min([max([get(g:, 'seoul256_background', 237), 234]), 239])
+if get(g:, "seoul256_forced_background", 0)
+  let s:seoul256_background = g:seoul256_forced_background
+else
+  let s:seoul256_background = min([max([get(g:, 'seoul256_background', 237), 234]), 239])
+endif
 
 if !has('gui_running')
   set t_Co=256
@@ -283,7 +287,7 @@ call s:hi('GitGutterChange', 65, '')
 call s:hi('GitGutterDelete', 161, '')
 call s:hi('GitGutterChangeDelete', 168, '')
 
-" http://vim.wikia.com/wiki/Highlight_unwanted_spaces     
+" http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 " ---------------------------------------------------^^^^^
 call s:hi('ExtraWhitespace', '', s:seoul256_background - 1)
 


### PR DESCRIPTION
Sometimes users might want colors beyond the designed range. In my case the perfect background is 233. 234 interferes with the vim-powerline status line. The `forced_background` option allows determined users to set the extact background they want.
