### PR TITLE
Emacs theme port

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ iTerm2 color scheme
 - [seoul256-iTerm2](https://github.com/mikker/seoul256-iTerm2) by
 [Mikkel Malmberg](https://github.com/mikker).
 
+Emacs color theme
+-------------------
+
+- [seoul256-emacs](https://github.com/anandpiyer/seoul256-emacs)
+
 Author
 ------
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ iTerm2 color scheme
 [Mikkel Malmberg](https://github.com/mikker).
 
 Emacs color theme
--------------------
+-----------------
 
 - [seoul256-emacs](https://github.com/anandpiyer/seoul256-emacs)
 


### PR DESCRIPTION
@junegunn, I have been using seoul256 for a long time, and I think it is one of the best low contrast schemes around. Recently I started using Emacs also, and wanted to get a consistent experience. So I ported your theme to Emacs. If you find it useful, you can add it to the list of ports. :)