### PR TITLE
Correctly escape file path for 'execute' command.

### DIFF
--- a/colors/seoul256-light.vim
+++ b/colors/seoul256-light.vim
@@ -64,7 +64,7 @@ if !empty(s:master)
       set background=light
     endif
     let g:colors_name = 'seoul256'
-    execute 'silent source '.s:master
+    execute 'silent source' . fnameescape(s:master)
     let g:colors_name = &background == 'dark' ? 'seoul256' : 'seoul256-light'
   finally
     " Revert g:seoul256_background


### PR DESCRIPTION
The previous seoul256-light color scheme would not work when rtp
contained spaces (e.g. if the user's directory would be "Firstname
Lastname") since s:master would contain spaces, which would then be
split into two arguments for the later 'execute' command.  Instead, the
path should be escaped using 'fnameescape' so the argument does not get
mangled by vim.