### PR TITLE
Ensure Cursor highlight group uses inverse colors

### DIFF
--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -422,6 +422,7 @@ call s:hi('rubyCurlyBlockDelimiter', [144, 101], ['', ''])
 call s:hi('rubyPredefinedIdentifier', [230, 52], ['', ''])
 " hi rubyRegexpSpecial
 
+hi Cursor cterm=inverse gui=inverse
 hi CursorLine cterm=NONE
 hi CursorLineNr cterm=NONE
 


### PR DESCRIPTION
When using Neovim with `set termguicolors`, the cursor is black due to the calls to `highlight clear` and `syntax reset`. Always defining the Cursor highlight group fixes the issue.

Note: vim is not effected.

Black Cursor
![black-cursor](https://cloud.githubusercontent.com/assets/25094/24807091/83f54098-1b7c-11e7-9f6b-9844a1a31c0b.png)

Inverted Color Cursor (expected behavior)
![inverse-cursor](https://cloud.githubusercontent.com/assets/25094/24807095/85f046a4-1b7c-11e7-89fb-cd9bc4e93540.png)

Update: It may also be terminal related. The issue is present in Gnome Terminal 3.18.3. I couldn't reproduce the problem in iTerm 2.