### PR TITLE
Add light color scheme for URxvt

### DIFF
--- a/urxvt/seoul256-light
+++ b/urxvt/seoul256-light
@@ -1,0 +1,23 @@
+! seoul256 (light) theme adapted for URxvt
+! append the content of this file to your .Xresources
+URxvt*background: #dadada
+URxvt*foreground: #4e4e4e
+URxvt*color0: #4e4e4e
+URxvt*color1: #af5f5f
+URxvt*color2: #5f885f
+URxvt*color3: #af8760
+URxvt*color4: #5f87ae
+URxvt*color5: #875f87
+URxvt*color6: #5f8787
+URxvt*color7: #e4e4e4
+URxvt*color8: #3a3a3a
+URxvt*color9: #870100
+URxvt*color10: #005f00
+URxvt*color11: #d8865f
+URxvt*color12: #0087af
+URxvt*color13: #87025f
+URxvt*color14: #008787
+URxvt*color15: #eeeeee
+URxvt*cursorColor: #4e4e4e
+URxvt*cursorColor2: #dadada
+URxvt*colorBD: #3a3a3a


### PR DESCRIPTION
I added it in the same format as [the dark version](https://github.com/junegunn/seoul256.vim/blob/master/urxvt/seoul256).

I actually don't think `cursorColor`, `cursorColor2`, and `colorBD` are needed, because URxvt will figure that out based on `foreground` and `background` - but that's a different issue.