### PR TITLE
Do not use runtimepath to look for seoul256.vim.

### DIFF
--- a/colors/seoul256-light.vim
+++ b/colors/seoul256-light.vim
@@ -33,7 +33,8 @@
 " OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-let s:master    = get(split(globpath(&rtp, 'colors/seoul256.vim'), '\n'), 0, '')
+let s:colors_dir= fnamemodify(resolve(expand('<sfile>:p')), ':h')
+let s:master    = get(globpath(s:colors_dir, 'seoul256.vim', 1, 1), 0, '')
 let s:custom_bg = get(g:, 'seoul256_light_background', get(g:, 'seoul256_background', 253))
 let s:light     = s:custom_bg >= 252 && s:custom_bg <= 256
 let s:var_found = exists('g:seoul256_background')


### PR DESCRIPTION
When using packages (`:help packages`), the path to seoul256 may not be
in `runtimepath` (the user may put the colorscheme inside a `pack/*/opt`
directory), in which case seoul256.vim will not be found when
loading seoul256-light.vim. To fix the problem, compute the path
relative to the path of the sourced file.