### PR TITLE
Add italic comments and rich markdown highlighting

### DIFF
--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -369,6 +369,13 @@ call s:hi('WarningMsg', [179, 88], ['', ''])
 " Sign column
 call s:hi('SignColumn', [173, 173], [s:dark_bg, s:light_bg])
 
+" Italic comments
+hi Comment gui=italic cterm=italic
+
+" Rich markdown highlighting
+hi markdownItalic gui=italic cterm=italic
+hi markdownBold gui=bold cterm=bold
+
 " Diff
 call s:hi('diffAdded',   [108, 65], ['', ''])
 call s:hi('diffRemoved', [174, 131], ['', ''])


### PR DESCRIPTION
Adding `hi Comment gui=italic cterm=italic`, `hi markdownItalic gui=italic cterm=italic` and `hi markdownBold gui=bold cterm=bold` was not working in my init.vim, but only when true color was enabled. I searched for a long time, but found no solution, so I decided that someone might also want these changes. This is why I have decided to submit a PR!