### PR TITLE
add support for ap/vim-buftabline

### DIFF
--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -367,7 +367,7 @@ call s:hi('Question', [179, 88], ['', ''])
 call s:hi('WarningMsg', [179, 88], ['', ''])
 
 " Sign column
-call s:hi('SignColumn', [173, 173], [s:dark_bg, s:light_bg])
+call s:hi('SignColumn', [101, 101], [s:dark_bg + 1, s:light_bg - 2])
 
 " Diff
 call s:hi('diffAdded',   [108, 65], ['', ''])

--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -405,8 +405,16 @@ call s:hi('SignifySignAdd', [108, 65], [s:dark_bg + 1, s:light_bg - 2])
 call s:hi('SignifySignChange', [68, 68], [s:dark_bg + 1, s:light_bg - 2])
 call s:hi('SignifySignDelete', [161, 161], [s:dark_bg + 1, s:light_bg - 2])
 
+" buftabline
+" -----------
+call s:hi('BufTabLineCurrent', [95, 95], [187, 187])
+hi BufTabLineCurrent cterm=bold,reverse gui=bold,reverse
+call s:hi('BufTabLineActive', [s:dark_bg + 2, s:light_bg - 2], [187, 238])
+hi BufTabLineActive cterm=reverse gui=reverse
+call s:hi('BufTabLineHidden', [s:dark_bg + 12, s:light_bg - 12], ['', ''])
+call s:hi('BufTabLineFill', ['', ''], [s:dark_bg, s:light_bg])
 
-" http://vim.wikia.com/wiki/Highlight_unwanted_spaces     
+" http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 " ---------------------------------------------------^^^^^
 call s:hi('ExtraWhitespace', ['', ''], [s:dark_bg - 1, s:light_bg - 2])
 


### PR DESCRIPTION
![Screenshot 2019-03-21 at 22 16 16](https://user-images.githubusercontent.com/7129888/54775786-21bdcb00-4c28-11e9-9e2d-ea51cd437086.png)

`BufTabLineCurrent` (currently focused buffer): same as `StatusLine`
`BufTabLineActive` (visible to user buffers): same as `StatusLineNC`
`BufTabLineFill` (tabline's bg): same as bg
`BufTabLineHidden` (opened but invisible buffers): have no bg (hence bg is same as `BufTabLineFill`)