### PR TITLE
Add a dark background for coc.nvim floats

### DIFF
--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -405,6 +405,9 @@ call s:hi('SignifySignAdd', [108, 65], [s:dark_bg + 1, s:light_bg - 2])
 call s:hi('SignifySignChange', [68, 68], [s:dark_bg + 1, s:light_bg - 2])
 call s:hi('SignifySignDelete', [161, 161], [s:dark_bg + 1, s:light_bg - 2])
 
+" coc.nvim
+call s:hi('CocFloating', [224, 96], [s:dark_bg - 2, s:light_bg - 2])
+
 
 " http://vim.wikia.com/wiki/Highlight_unwanted_spaces     
 " ---------------------------------------------------^^^^^


### PR DESCRIPTION
Coc.nvim displays additional info from the language server in a Neovim
floating window.
This info often contains source code which is properly syntax
highlighted.

Coc.nvim uses the Pmenu background color for the floating
window by default (which is pink in seoul256), which makes syntax
highlighted code in it very much unreadable.

Fortunately, Coc.nvim has a highlight group for the floating window
background, so we can easily change its color.

I've changed the color to be a darker background (dark_bg - 2 and
light_bg - 2) color with a pink foreground (just like Pmenu's bg),
giving it a really nice look.