### PR TITLE
ensure Todo highlight on dark bg is at least 233

### DIFF
--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -227,7 +227,7 @@ call s:hi('Conditional', [110, 31], ['', ''])
 
 " while end
 call s:hi('Repeat', [68, 67], ['', ''])
-call s:hi('Todo', [161, 125], [s:dark_bg_2, s:light_bg_2])
+call s:hi('Todo', [161, 125], [max([s:dark_bg - 2, 233]), s:light_bg_2])
 call s:hi('Function', [187, 58], ['', ''])
 
 " Macros


### PR DESCRIPTION
- note
  - existing `s:dark_bg_2` handling is beneficial for `hl-VertSplit`
    - hence
      - this variable is kept in tact
- previously
  - with `g:seoul256_background` set to 233
    - todo syntax was rendered with visually jarring effect
      - as bg colors dropped to #000000
- now
  - use the equivalent to light bg handling for dark bg todos
    - for equivalently balanced visual effect
    - see: `s:light_bg_2`