### PR TITLE
Fix color inversion for status line on Neovim

### DIFF
--- a/colors/seoul256.vim
+++ b/colors/seoul256.vim
@@ -351,6 +351,8 @@ call s:hi('StatusLine', [95, 95], [187, 187])
 call s:hi('StatusLineNC', [s:dark_bg + 2, s:light_bg - 2], [187, 238])
 call s:hi('StatusLineTerm', [95, 95], [187, 187])
 call s:hi('StatusLineTermNC', [s:dark_bg + 2, s:light_bg - 2], [187, 238])
+hi StatusLine cterm=bold,reverse gui=bold,reverse
+hi StatusLineNC cterm=bold,reverse gui=bold,reverse
 hi StatusLineTerm cterm=bold,reverse gui=bold,reverse
 hi StatusLineTermNC cterm=bold,reverse gui=bold,reverse
 call s:hi('TabLineFill', [s:dark_bg + 2, s:light_bg - 2], ['', ''])


### PR DESCRIPTION
Vim highlights options for status line stuff have `gui` and `cterm` set to `bold,reverse` by default, but Neovim highlights don't. As a result the status line does not have the colors inverted and thus sticks out.

### Before

<img width="1043" height="522" alt="seoul256-before" src="https://github.com/user-attachments/assets/a4894815-3258-46e7-bb7f-5d8117c7483c" />

### After

<img width="1048" height="559" alt="seoul256-after" src="https://github.com/user-attachments/assets/ec65b464-d799-4249-a854-fbcc6d1a72d0" />

### See Also

```VimL
vim -u NONE
:hi StatusLine
StatusLine     xxx term=bold,reverse cterm=bold,reverse gui=bold,reverse
```

```VimL
nvim -u NONE
:hi StatusLine
StatusLine     xxx cterm=reverse guifg=NvimLightGrey2 guibg=NvimDarkGrey4
```